### PR TITLE
Support for Python 3.7.0

### DIFF
--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -1,1 +1,12 @@
-FROM python:3.6-onbuild
+FROM python:3.7.0
+
+EXPOSE 5000
+
+RUN mkdir -p /usr/src/app
+WORKDIR /usr/src/app
+
+RUN apt-get install libssl-dev libffi-dev
+
+COPY requirements.txt /usr/src/app/
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . /usr/src/app


### PR DESCRIPTION
The official python onbuild images are deprecated